### PR TITLE
fix: pass coach kwarg through orchestrator subclasses

### DIFF
--- a/kodo/orchestrators/claude_code.py
+++ b/kodo/orchestrators/claude_code.py
@@ -46,6 +46,7 @@ class ClaudeCodeOrchestrator(OrchestratorBase):
         config: CycleConfig | None = None,
         advisory_queue=None,
         observer=None,
+        coach=None,
     ) -> CycleResult:
         if config is None:
             config = CycleConfig()

--- a/kodo/orchestrators/kimi_code.py
+++ b/kodo/orchestrators/kimi_code.py
@@ -44,6 +44,7 @@ class KimiCodeOrchestrator(OrchestratorBase):
         config: CycleConfig | None = None,
         advisory_queue=None,
         observer=None,
+        coach=None,
     ) -> CycleResult:
         if config is None:
             config = CycleConfig()

--- a/tests/test_orchestrator_signatures.py
+++ b/tests/test_orchestrator_signatures.py
@@ -1,0 +1,47 @@
+"""Verify all orchestrator `cycle` methods accept the `coach` kwarg.
+
+`OrchestratorBase.run()` unconditionally forwards `coach=coach` to
+`self.cycle(...)`. Any subclass that overrides `cycle` without declaring
+`coach` raises ``TypeError`` on the first cycle. These tests guard against
+regressions by inspecting the resolved signature for each orchestrator class
+(works whether `coach` is declared on the override or inherited).
+"""
+
+import inspect
+
+from kodo.orchestrators.api import ApiOrchestrator
+from kodo.orchestrators.claude_code import ClaudeCodeOrchestrator
+from kodo.orchestrators.codex_cli import CodexOrchestrator
+from kodo.orchestrators.cursor_cli import CursorOrchestrator
+from kodo.orchestrators.gemini_cli import GeminiCliOrchestrator
+from kodo.orchestrators.kimi_code import KimiCodeOrchestrator
+
+ORCHESTRATORS = [
+    ApiOrchestrator,
+    ClaudeCodeOrchestrator,
+    CodexOrchestrator,
+    CursorOrchestrator,
+    GeminiCliOrchestrator,
+    KimiCodeOrchestrator,
+]
+
+
+def test_all_orchestrators_accept_coach_kwarg():
+    missing = []
+    for cls in ORCHESTRATORS:
+        sig = inspect.signature(cls.cycle)
+        if "coach" not in sig.parameters:
+            missing.append(cls.__name__)
+    assert not missing, f"orchestrators missing 'coach' kwarg: {missing}"
+
+
+def test_coach_param_is_keyword_compatible():
+    """`coach` must be passable as a keyword argument."""
+    for cls in ORCHESTRATORS:
+        sig = inspect.signature(cls.cycle)
+        param = sig.parameters.get("coach")
+        assert param is not None, f"{cls.__name__}.cycle missing 'coach'"
+        assert param.kind in (
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ), f"{cls.__name__}.cycle 'coach' not keyword-compatible: {param.kind}"


### PR DESCRIPTION
## Summary

`OrchestratorBase.run()` unconditionally passes `coach=coach` to `self.cycle()`, but two subclasses override `cycle()` without declaring the parameter, causing `TypeError` on the first cycle:

- `ClaudeCodeOrchestrator.cycle()` — `kodo/orchestrators/claude_code.py`
- `KimiCode.cycle()` — `kodo/orchestrators/kimi_code.py`

The other CLI orchestrators (Codex, Cursor, Gemini) inherit `CliOrchestratorBase.cycle` which already accepts `coach=None` and were unaffected.

## Reproduction

```
kodo --orchestrator claude-code:sonnet --team quick \
  --goal "..." --project ... --skip-intake --yes --cycles 1
```

→ `TypeError: cycle() got an unexpected keyword argument 'coach'` on first cycle.

## Fix

Add `coach=None` to the two overriding `cycle()` signatures (received but unused, matching `ApiOrchestrator`'s pattern). Add `tests/test_orchestrator_signatures.py` using `inspect.signature` to enforce the contract for all orchestrators.

## Test plan

- [x] `pytest tests/test_orchestrator_signatures.py` passes locally
- [x] Reproduction case (Claude Code orchestrator with `quick` team) no longer raises TypeError