### PR TITLE
fix: ship dashboard static files in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ filterwarnings = [
 include = ["kodo*", "benchmark*"]
 
 [tool.setuptools.package-data]
-kodo = ["*.html"]
+kodo = ["*.html", "dashboard/*.html", "dashboard/*.css", "dashboard/*.js"]
 benchmark = ["online/static/*.html"]
 
 [project.scripts]

--- a/tests/test_dashboard_assets.py
+++ b/tests/test_dashboard_assets.py
@@ -1,0 +1,33 @@
+"""Regression test: dashboard static assets must be packaged with kodo.
+
+Without these files, `python -m kodo.dashboard` binds successfully but every
+HTTP request crashes with FileNotFoundError on dashboard.html. Strict build
+backends (uv, poetry-core) only include files explicitly declared in
+[tool.setuptools.package-data], unlike pip+setuptools which auto-includes
+tracked files. So the source tree carrying these files is necessary but not
+sufficient — the package-data declaration must list them too.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import kodo.dashboard
+
+
+def test_dashboard_static_files_present_in_source_tree() -> None:
+    dashboard_dir = Path(kodo.dashboard.__file__).parent
+    expected = ["dashboard.html", "dashboard.css", "dashboard.js"]
+    missing = [name for name in expected if not (dashboard_dir / name).is_file()]
+    assert not missing, f"dashboard static files missing from package: {missing}"
+
+
+def test_dashboard_assets_declared_in_package_data() -> None:
+    """Pin the explicit declaration so strict build backends (uv) include the files."""
+    repo_root = Path(__file__).resolve().parent.parent
+    pyproject = (repo_root / "pyproject.toml").read_text()
+    for pattern in ("dashboard/*.html", "dashboard/*.css", "dashboard/*.js"):
+        assert pattern in pyproject, (
+            f"missing package-data pattern {pattern!r} in pyproject.toml — "
+            f"strict build backends will exclude dashboard assets from the wheel"
+        )


### PR DESCRIPTION
## Summary

`[tool.setuptools.package-data]` only included `kodo = [\"*.html\"]`, which matches top-level `kodo/*.html` only. The dashboard's static assets at `kodo/dashboard/dashboard.{html,css,js}` were excluded by strict build backends.

\`pip\` + setuptools auto-includes tracked files when building the wheel and silently hides the bug. \`uv\` (and other PEP 517-strict backends) only ship what \`package-data\` declares. So:

\`\`\`
uv pip install kodo
python -m kodo.dashboard --port 8050 --no-open
# Server starts and prints \"Dashboard: http://127.0.0.1:8050\"
curl http://127.0.0.1:8050/
# → 500, log shows:
# FileNotFoundError: '.../site-packages/kodo/dashboard/dashboard.html'
\`\`\`

I hit this while wiring kodo's dashboard into an external launcher. \`python -m kodo.dashboard\` binds the port and prints the URL fine — only the first HTTP request crashes. The packaging issue is only visible at request time, which made it surprising.

## Fix

One line in \`pyproject.toml\`:

\`\`\`diff
 [tool.setuptools.package-data]
-kodo = [\"*.html\"]
+kodo = [\"*.html\", \"dashboard/*.html\", \"dashboard/*.css\", \"dashboard/*.js\"]
 benchmark = [\"online/static/*.html\"]
\`\`\`

## Regression test

\`tests/test_dashboard_assets.py\` adds two checks:
1. The static files exist in the source tree (catches accidental deletions).
2. The package-data patterns are declared in \`pyproject.toml\` (catches accidental config regressions for strict build backends).

Verified the second test fails red without the pyproject change and passes green with it.

## Test plan

- [x] \`pytest tests/test_dashboard_assets.py\` passes locally
- [x] Confirmed reproduction: \`uv pip install\` of \`syamai/kodo@dev\` (without this fix) → dashboard crashes; with this fix → dashboard serves \`/\` correctly
- [x] No behavior change to anything else; the patch only affects what the wheel ships

## Notes

This is a third small bug fix (companion to #49 and #50) found while building an external integration. Happy to bundle in a follow-up if maintainers prefer fewer PRs, but kept it standalone since the fix is independent and testable in isolation.